### PR TITLE
v0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Run tests
         run: |
-          python -m coverage run -m pytest -vvv -s
+          python -m coverage run -m pytest
           python -m coverage lcov
 
       - name: Python ${{ matrix.python-version }} Coveralls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 All notable changes to this project are documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- Oracle databases are now supported via driver `oracledb`. [#5]
+- (INTERNAL) `BaseDriver` subclasses can now optionally implement an `init_connection` method which is called right after a `PyDbAPIv2Connection` is created so as to perform any driver specific initializations on said connection. [#5]
+
+### Changed
+
+- (INTERNAL) Renamed certain functions to better convey their meaning. [#5]
+
+
 ## 0.1.1 [2025-11-26]
 
 ### Fixed
@@ -9,5 +21,5 @@ All notable changes to this project are documented in this file.
       
 
 
-
+[#5]: https://github.com/manoss96/onlymaps/pull/5
 [#6]: https://github.com/manoss96/onlymaps/pull/6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ All notable changes to this project are documented in this file.
 ### Added
 
 - Oracle databases are now supported via driver `oracledb`. [#5]
+- DuckDB databases are now supported via driver `duckdb`. [#14]
 - Added support for `decimal.Decimal` type. [#13]
-- (INTERNAL) `BaseDriver` subclasses can now optionally implement an `init_connection` method which is called right after a `PyDbAPIv2Connection` is created so as to perform any driver specific initializations on said connection. [#5]
+- (INTERNAL) `BaseDriver` subclasses can now optionally implement an `init_connection` method which is called right after a `PyDbAPIv2Connection` is created so as to perform any driver-specific initialization steps on said connection. [#5,#14]
+- (INTERNAL) `BaseDriver` subclasses can now optionally implement an `init_transaction` method which is called right before a
+transaction is to be started so as to perform any driver-specific initialization steps regarding the transaction. [#14]
 
 
 ### Changed
@@ -38,3 +41,4 @@ separate method `__cursor`. [#10]
 [#10]: https://github.com/manoss96/onlymaps/pull/10
 [#11]: https://github.com/manoss96/onlymaps/pull/11
 [#13]: https://github.com/manoss96/onlymaps/pull/13
+[#14]: https://github.com/manoss96/onlymaps/pull/14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project are documented in this file.
 
-## [Unreleased]
+## 0.2.0 [2026-01-11]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ All notable changes to this project are documented in this file.
 
 - (INTERNAL) Renamed certain functions to better convey their meaning. [#5]
 
+### Fixed
+
+- Bug that resulted in query parameters not being properly handled when wrapped within
+  `Bulk`. [#8]
+
 
 ## 0.1.1 [2025-11-26]
 
@@ -23,3 +28,4 @@ All notable changes to this project are documented in this file.
 
 [#5]: https://github.com/manoss96/onlymaps/pull/5
 [#6]: https://github.com/manoss96/onlymaps/pull/6
+[#8]: https://github.com/manoss96/onlymaps/pull/8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ All notable changes to this project are documented in this file.
 - Oracle databases are now supported via driver `oracledb`. [#5]
 - (INTERNAL) `BaseDriver` subclasses can now optionally implement an `init_connection` method which is called right after a `PyDbAPIv2Connection` is created so as to perform any driver specific initializations on said connection. [#5]
 
+
 ### Changed
 
 - (INTERNAL) Renamed certain functions to better convey their meaning. [#5]
+- (INTERNAL) Simplified method `onlymaps._connection.Connection._safe_cursor` by moving the cursor-obtaining logic into a
+separate method `__cursor`. [#10]
+- (INTERNAL) Added private method `onlymaps._connection.Connection.__close` so as to remove duplicated logic. [#10]
 
 ### Fixed
 
@@ -29,3 +33,4 @@ All notable changes to this project are documented in this file.
 [#5]: https://github.com/manoss96/onlymaps/pull/5
 [#6]: https://github.com/manoss96/onlymaps/pull/6
 [#8]: https://github.com/manoss96/onlymaps/pull/8
+[#10]: https://github.com/manoss96/onlymaps/pull/10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented in this file.
 ### Added
 
 - Oracle databases are now supported via driver `oracledb`. [#5]
+- Added support for `decimal.Decimal` type. [#13]
 - (INTERNAL) `BaseDriver` subclasses can now optionally implement an `init_connection` method which is called right after a `PyDbAPIv2Connection` is created so as to perform any driver specific initializations on said connection. [#5]
 
 
@@ -36,3 +37,4 @@ separate method `__cursor`. [#10]
 [#8]: https://github.com/manoss96/onlymaps/pull/8
 [#10]: https://github.com/manoss96/onlymaps/pull/10
 [#11]: https://github.com/manoss96/onlymaps/pull/11
+[#13]: https://github.com/manoss96/onlymaps/pull/13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project are documented in this file.
 - Oracle databases are now supported via driver `oracledb`. [#5]
 - DuckDB databases are now supported via driver `duckdb`. [#14]
 - Added support for `decimal.Decimal` type. [#13]
-- (INTERNAL) `BaseDriver` subclasses can now optionally implement an `init_connection` method which is called right after a `PyDbAPIv2Connection` is created so as to perform any driver-specific initialization steps on said connection. [#5,#14]
+- (INTERNAL) `BaseDriver` subclasses can now optionally implement an `init_connection` method which is called right after a `PyDbAPIv2Connection` is created so as to perform any driver-specific initialization steps on said connection. [#5], [#14]
 - (INTERNAL) `BaseDriver` subclasses can now optionally implement an `init_transaction` method which is called right before a
 transaction is to be started so as to perform any driver-specific initialization steps regarding the transaction. [#14]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project are documented in this file.
 - (INTERNAL) Simplified method `onlymaps._connection.Connection._safe_cursor` by moving the cursor-obtaining logic into a
 separate method `__cursor`. [#10]
 - (INTERNAL) Added private method `onlymaps._connection.Connection.__close` so as to remove duplicated logic. [#10]
+- (INTERNAL) Minor code improvements and fixes in `onlymaps._utils.py` and `tests.utils.py`. [#11]
 
 ### Fixed
 
@@ -34,3 +35,4 @@ separate method `__cursor`. [#10]
 [#6]: https://github.com/manoss96/onlymaps/pull/6
 [#8]: https://github.com/manoss96/onlymaps/pull/8
 [#10]: https://github.com/manoss96/onlymaps/pull/10
+[#11]: https://github.com/manoss96/onlymaps/pull/11

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The `{DB_TYPE}` placeholder can take any of the following values depending on th
 - `mariadb`: MariaDB
 - `oraceldb`: Oracle Database
 - `sqlite`: SQLite. More specifically, when connecting to a SQLite database, your connection string must be formatted as such: `sqlite:///{DB_NAME}`.
+- `duckdb`: DuckDB. Similarly, when connecting to a DuckDB database, your connection string must be formatted as such: `duckdb:///{DB_NAME}`.
 
 #### Using unsupported drivers
 

--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ In general, when querying a single column, the following types are supported:
 - `bool`
 - `int`
 - `float`
+- `decimal.Decimal`
 - `str`
 - `bytes`
 - `uuid.UUID`

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ db.open()
 db.close()
 ```
 
-Since the sync and async APIs are identical, from now on we will be using the sync API for all examples. You only have to remeber that when using the async API, methods must be awaited:
+Since the sync and async APIs are identical, from now on we will be using the sync API for all examples. You only have to remember that when using the async API, methods must be awaited:
 
 ```python
 from onlymaps.asyncio import connect, AsyncDatabase

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![OnlyMaps Logo](docs/source/onlymaps.png)
 
 
-Onlymaps is a Python micro-ORM library that enables you to interact with a database
+Onlymaps is a Python micro-ORM library that lets you interact with a database
 through plain SQL queries while it takes care of mapping the results back to Python
 objects. More specifically, it provides:
 
@@ -103,6 +103,7 @@ The `{DB_TYPE}` placeholder can take any of the following values depending on th
 - `mysql`: MySQL
 - `mssql`: Microsoft SQL Server
 - `mariadb`: MariaDB
+- `oraceldb`: Oracle Database
 - `sqlite`: SQLite. More specifically, when connecting to a SQLite database, your connection string must be formatted as such: `sqlite:///{DB_NAME}`.
 
 #### Using unsupported drivers
@@ -392,7 +393,7 @@ If you wish to retain that, you should use a model type:
 ```python
 rows: list[dict] = db.fetch_many(dict, "SELECT id, label FROM my_table")
 
-print(rows.keys()) # This prints `dict_keys(['id', 'label'])`.
+print(rows[0].keys()) # This prints `dict_keys(['id', 'label'])`.
 ```
 
 You can use whichever suits you best, as both container types and

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ objects. More specifically, it provides:
 
 - A minimal API that enables both sync and async query execution.
 - Fine-grained type-hinting and validation with the help of [Pydantic](https://docs.pydantic.dev/latest/).
-- Support for all major databases such as PostgreSQL, MySQL, MariaDB and MS SQL Server.
+- Support for all major databases such as PostgreSQL, MySQL, MariaDB, MS SQL Server and more.
 - Connection pooling via custom implementation.
 
 ## How to install 📦
@@ -56,7 +56,7 @@ with connect("postgresql://user:password@localhost:5432/mydb") as db:
     # Execute queries...
 ```
 
-Similarly, `onlymaps.asyncio.connect` gives access to the `AsyncDatabase` API:
+Similarly, `onlymaps.asyncio.connect` gives access to its async counterpart, namely `AsyncDatabase`:
 
 ```python
 from onlymaps.asyncio import connect
@@ -160,7 +160,7 @@ a connection pool with an adequate number of connections, where each thread
 can get its own connection from the pool.
 
 The same is true for the async variants as well. Both the async connection and the
-async connection pool can be considered reentrant, as long as they are not accessed
+async connection pool can be considered concurrency-safe, as long as they are not accessed
 outside the event loop in which they were created. When it comes to their performance,
 connection pooling is again the right choice for a heavily concurrent application,
 for example an ASGI web server.
@@ -201,7 +201,7 @@ class User(BaseModel):
 users: list[User] = db.fetch_many(User, "SELECT name, age FROM users")
 ```
 
-Even though the above example uses a pydantic model, you are not required to use one.
+Even though the above example uses a Pydantic model, you are not required to use one.
 In fact, you can use any type you like as long as it matches the query result you are
 expecting:
 
@@ -317,8 +317,8 @@ exits successfully, all changes are persisted.
 
 ### Mapping query results
 
-In order to understand how rows are mapped to Python objects, we should first
-make the distinction of querying a single column versus querying multiple columns.
+In order to better understand how rows are mapped to Python objects, it is crucial
+that we make the distinction between querying a single column and querying multiple columns.
 
 ##### Single-column queries
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ you should use, you can take a look at the documentation of the driver you are u
 
 #### Query parameter wrappers
 
-Onlymaps does some parameter handling by default when it makes sense to do so. To give an example, `UUID` and `pydantic.BaseModel` type instances are always converted into strings when provided as query parameters, as this is the only type conversion that makes sense in this context. However, there exist certain cases where it is not so obvious how a parameter is meant to be used. Consider the following example:
+Onlymaps does some parameter handling by default when it makes sense to do so. To give an example, `uuid.UUID` and `pydantic.BaseModel` type instances are always converted into strings when provided as query parameters, as this is the only type conversion that makes sense in this context. However, there exist certain cases where it is not so obvious how a parameter is meant to be used. Consider the following example:
 
 ```python
 ids = [1, 2, 3, 4, 5]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 
 Onlymaps is a Python micro-ORM library that lets you interact with a database
-through plain SQL queries while it takes care of mapping the results back to Python
+through plain SQL while it takes care of mapping any query results back to Python
 objects. More specifically, it provides:
 
 - A minimal API that enables both sync and async query execution.
@@ -202,8 +202,7 @@ users: list[User] = db.fetch_many(User, "SELECT name, age FROM users")
 ```
 
 Even though the above example uses a Pydantic model, you are not required to use one.
-In fact, you can use any type you like as long as it matches the query result you are
-expecting:
+In fact, you can use any type you like as long as it matches the result you are expecting:
 
 ```python
 users: list[tuple[str, int]] = db.fetch_many(tuple[str, int], "SELECT name, age FROM users")
@@ -285,7 +284,8 @@ db.exec("INSERT INTO my_table (col_a, col_b) VALUES (%s, %s)", Json(ids), Json(k
 Both `ids` and `kv_pairs` are converted into JSON-compatible strings, which are then inserted
 into the table columns `col_a` and `col_b` respectively.
 
-Other than `Json`, there exists one more parameter wrapper class, namely `Bulk`, which in turn indicates that the provided argument is to be executed as part of a bulk statement:
+Other than `Json`, there exists one more parameter wrapper class, namely `Bulk`, which in turn indicates
+that the provided argument is to be executed as part of a bulk statement:
 
 ```python
 from onlymaps import Bulk

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ In general, when querying a single column, the following types are supported:
 
 Things are a bit different when querying multiple columns, as the type you must use
 should always be some sorts of struct type which is able to contain more than one
-types of data:
+type of data:
 
 ```python
 rows: list[tuple] = db.fetch_many(tuple, "SELECT id, label FROM my_table")

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The `{DB_TYPE}` placeholder can take any of the following values depending on th
 - `mysql`: MySQL
 - `mssql`: Microsoft SQL Server
 - `mariadb`: MariaDB
-- `sqlite`: SQLite. More specifically, when connecting to a SQLite database, your connection string must be formatted as such: `sqlite:///${DB_NAME}`.
+- `sqlite`: SQLite. More specifically, when connecting to a SQLite database, your connection string must be formatted as such: `sqlite:///{DB_NAME}`.
 
 #### Using unsupported drivers
 
@@ -365,7 +365,7 @@ In general, when querying a single column, the following types are supported:
 
 Things are a bit different when querying multiple columns, as the type you must use
 should always be some sorts of struct type which is able to contain more than one
-type of data:
+types of data:
 
 ```python
 ids: list[tuple] = db.fetch_many(tuple, "SELECT id, label FROM my_table")
@@ -384,7 +384,7 @@ The complete list of types supported when querying multiple columns is as follow
 This  above list of struct types can be further separated into two distinct categories:
 
 - Container types: `tuple`, `list`, `set`.
-- Model types: `dict`, `dataclasses.dataclass`, `pydantic.dataclasses.dataclass`, `pydanticBaseModel`
+- Model types: `dict`, `dataclasses.dataclass`, `pydantic.dataclasses.dataclass`, `pydantic.BaseModel`
 
 When using a container type, you lose all information regarding the column names.
 If you wish to retain that, you should use a model type:

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ db = connect(conn_factory)
 ```
 
 You only have to remember that, for this to work, the factory function must output connection
-instances that implement the `Connection` interface of the [Python Database API Specification v2.0](https://peps.python.org/pep-0249/).
+instances that implement the `Connection` interface of [Python Database API Specification v2.0](https://peps.python.org/pep-0249/).
 Therefore, as long as a Python database driver package is compatible with the afformentioned protocol,
 you can use it and it will work just fine!
 
@@ -339,7 +339,7 @@ class JsonColumn(BaseModel):
     label: str
     metadata: str | None = None
 
-json_rows: list[JsonColumn] = db.fetch_many(JsonColumn, "SELECT json_col FROM my_table")
+json_cols: list[JsonColumn] = db.fetch_many(JsonColumn, "SELECT json_col FROM my_table")
 ```
 
 In general, when querying a single column, the following types are supported:
@@ -369,7 +369,7 @@ should always be some sorts of struct type which is able to contain more than on
 types of data:
 
 ```python
-ids: list[tuple] = db.fetch_many(tuple, "SELECT id, label FROM my_table")
+rows: list[tuple] = db.fetch_many(tuple, "SELECT id, label FROM my_table")
 ```
 
 The complete list of types supported when querying multiple columns is as follows:
@@ -403,14 +403,14 @@ type of values you are expecting:
 ```python
 
 # This works!
-ids1 = db.fetch_many(tuple[int, str], "SELECT id, label FROM my_table")
+rows1 = db.fetch_many(tuple[int, str], "SELECT id, label FROM my_table")
 
 # And this works!
-ids2 = db.fetch_many(dict[str, int | str], "SELECT id, label FROM my_table")
+rows2 = db.fetch_many(dict[str, int | str], "SELECT id, label FROM my_table")
 
 # But these two raise a `TypeError`.
-ids3 = db.fetch_many(tuple[int, int], "SELECT id, label FROM my_table")
-ids4 = db.fetch_many(dict[str, int], "SELECT id, label FROM my_table")
+rows3 = db.fetch_many(tuple[int, int], "SELECT id, label FROM my_table")
+rows4 = db.fetch_many(dict[str, int], "SELECT id, label FROM my_table")
 ```
 
 

--- a/onlymaps/__init__.py
+++ b/onlymaps/__init__.py
@@ -16,7 +16,7 @@ try:
     import onlymaps.asyncio as _
 except ImportError as exc:  # pragma: no cover
     raise ImportError(
-        "Generate the async API by running `python genasync.py`."
+        "Generate the async API by running `python gen_async.py`."
     ) from exc
 # <ignore>
 

--- a/onlymaps/__init__.pyi
+++ b/onlymaps/__init__.pyi
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 Manos Stoumpos
+# Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+"""
+This is a stub file for `__init__.py`.
+"""
+
 from typing import Any, Literal, overload
 
 from onlymaps._params import Bulk, Json

--- a/onlymaps/_connection.py
+++ b/onlymaps/_connection.py
@@ -234,10 +234,10 @@ class Connection:
         Executes the given SQL query.
 
         :param str sql: The SQL query to be executed.
-        :param tuple[Any, ...] params: A tuple containing positional
-            parameters for the query.
-        :param dict[str, Any] kwparams: A dictionary containing keyword
-            parameters for the query.
+        :param Any *args: A sequence of positional arguments to be used
+            as query parameters.
+        :param Any **kwargs: A sequence of keyword arguments to be used
+            as query parameters.
 
         :raises RuntimeError: Connection is not open.
         """
@@ -255,10 +255,10 @@ class Connection:
         :param `T` | ellipsis t: The type to which the query result is mapped.
             If an `ellipsis` is provided, then no type check/cast occurs.
         :param str sql: The SQL query to be executed.
-        :param tuple[Any, ...] params: A tuple containing positional
-            parameters for the query.
-        :param dict[str, Any] kwparams: A dictionary containing keyword
-            parameters for the query.
+        :param Any *args: A sequence of positional arguments to be used
+            as query parameters.
+        :param Any **kwargs: A sequence of keyword arguments to be used
+            as query parameters.
 
         :raises RuntimeError: Connection is not open.
         """
@@ -275,10 +275,10 @@ class Connection:
         :param `T` | ellipsis t: The type to which the query result is mapped.
             If an `ellipsis` is provided, then no type check/cast occurs.
         :param str sql: The SQL query to be executed.
-        :param tuple[Any, ...] params: A tuple containing positional
-            parameters for the query.
-        :param dict[str, Any] kwparams: A dictionary containing keyword
-            parameters for the query.
+        :param Any *args: A sequence of positional arguments to be used
+            as query parameters.
+        :param Any **kwargs: A sequence of keyword arguments to be used
+            as query parameters.
 
         :raises ValueError: No row object was found to return.
         :raises RuntimeError: Connection is not open.
@@ -296,10 +296,10 @@ class Connection:
         :param `T` | ellipsis t: The type to which the query result is mapped.
             If an `ellipsis` is provided, then no type check/cast occurs.
         :param str sql: The SQL query to be executed.
-        :param tuple[Any, ...] params: A tuple containing positional
-            parameters for the query.
-        :param dict[str, Any] kwparams: A dictionary containing keyword
-            parameters for the query.
+        :param Any *args: A sequence of positional arguments to be used
+            as query parameters.
+        :param Any **kwargs: A sequence of keyword arguments to be used
+            as query parameters.
 
         :raises RuntimeError: Connection is not open.
         """
@@ -324,10 +324,10 @@ class Connection:
             If an `ellipsis` is provided, then no type check/cast occurs.
         :param int size: The number of rows each batch contains.
         :param str sql: The SQL query to be executed.
-        :param tuple[Any, ...] params: A tuple containing positional
-            parameters for the query.
-        :param dict[str, Any] kwparams: A dictionary containing keyword
-            parameters for the query.
+        :param Any *args: A sequence of positional arguments to be used
+            as query parameters.
+        :param Any **kwargs: A sequence of keyword arguments to be used
+            as query parameters.
 
         :raises RuntimeError: Connection is not open.
         """

--- a/onlymaps/_connection.py
+++ b/onlymaps/_connection.py
@@ -208,6 +208,8 @@ class Connection:
             )
 
             try:
+                if not self.__in_transaction:
+                    self.__driver.init_transaction(self.__conn)
                 yield cursor
                 is_query_successful = True
             except:
@@ -368,6 +370,7 @@ class Connection:
         with self.__cursor_lock:  # <async>
             try:
                 self.__transaction_id = self.__context_id
+                self.__driver.init_transaction(self.__conn)
                 yield
                 self.__conn.commit()  # <await>
             except:
@@ -398,8 +401,9 @@ class Connection:
                 raise Error.DbOpenConnection
 
             try:
-                self.__conn = self.__conn_factory()  # <await>
-                self.__driver.init_connection(self.__conn)
+                self.__conn = self.__driver.init_connection(
+                    self.__conn_factory()  # <await>
+                )
                 self.__is_open = True
             except:
                 self.__is_open = False

--- a/onlymaps/_connection.py
+++ b/onlymaps/_connection.py
@@ -345,7 +345,7 @@ class Connection:
             finally:
                 self.__iteration_id = None
 
-    @contextmanager  # <async>
+    @contextmanager
     def transaction(self) -> Iterator[None]:  # <async>
         """
         Opens a trasnaction so that any changes caused by any

--- a/onlymaps/_drivers.py
+++ b/onlymaps/_drivers.py
@@ -10,9 +10,10 @@ parameters and their results.
 import json
 from abc import ABC, abstractmethod
 from dataclasses import is_dataclass
+from datetime import datetime
 from enum import Enum, StrEnum
 from functools import lru_cache
-from typing import Any, Callable, Self, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Self, TypeVar, final
 from uuid import UUID
 
 from pydantic import BaseModel, TypeAdapter
@@ -22,6 +23,14 @@ from typing_extensions import override
 
 from onlymaps._params import Json
 from onlymaps._types import OnlymapsBool, OnlymapsType
+
+if TYPE_CHECKING:
+    import oracledb
+else:
+    try:
+        import oracledb
+    except ImportError:
+        pass
 
 T = TypeVar("T")
 
@@ -35,6 +44,7 @@ class Driver(StrEnum):
     MY_SQL = "mysql"
     SQL_SERVER = "mssql"
     MARIA_DB = "mariadb"
+    ORACLE_DB = "oracledb"
     SQL_LITE = "sqlite"
     UNKNOWN = "?"
 
@@ -93,6 +103,16 @@ class BaseDriver(ABC):
         The driver's type.
         """
 
+    def init_connection(self, _: Any) -> None:
+        """
+        This function is used to perform any driver-specific
+        initialization logic right after the instantiation of
+        a PyDbAPIv2 connection.
+
+        :param Any conn: A PyDbAPIv2-compatible connection object.
+        """
+        return None
+
     def handle_sql_param(self, param: Any) -> Any:
         """
         Some Python types are not supported by certain drivers. This function
@@ -119,10 +139,21 @@ class BaseDriver(ABC):
             case _:
                 return param
 
+    def handle_sql_result_type(self, t: type) -> type:
+        """
+        Some SQL query results are returned in different formats by certain
+        drivers. This can be overridden by a driver class so as to handle
+        these cases.
+
+        :param type t: The type that is to be mapped.
+        """
+        return t
+
     # NOTE: Add LRU caching as type mapping can be expensive,
     #       especially for deeply nested model types.
+    @final
     @lru_cache(maxsize=256)
-    def handle_sql_result_type(
+    def get_adapter_and_inverse_map(
         self, t: type[T]
     ) -> tuple[TypeAdapter, Callable[[Any], T]]:
         """
@@ -138,20 +169,10 @@ class BaseDriver(ABC):
 
         :param type t: The type that is to be mapped.
         """
-        custom_type, map_to_original = OnlymapsType.factory(
-            t=t, field_type_mapper=self._handle_sql_result_type_impl
+        custom_type, inverse_map = OnlymapsType.factory(
+            t=t, field_type_mapper=self.handle_sql_result_type
         )
-        return (TypeAdapter(custom_type), map_to_original)
-
-    @abstractmethod
-    def _handle_sql_result_type_impl(self, t: type) -> type:
-        """
-        Some SQL query results are returned in different formats by certain
-        drivers. This function handles these cases by using custom type wrappers
-        which are capable of mapping sad results to their original type.
-
-        :param type t: The type that is to be mapped.
-        """
+        return (TypeAdapter(custom_type), inverse_map)
 
     @staticmethod
     @abstractmethod
@@ -167,8 +188,8 @@ class BaseDriver(ABC):
 
 class PostgresDriver(BaseDriver):
     """
-    This class represents the connection's underlying driver
-    and is used to handle driver-specific issues.
+    This class represents the underlying driver to a PostgreSQL
+    database and is used to handle driver-specific issues.
     """
 
     @property
@@ -177,16 +198,6 @@ class PostgresDriver(BaseDriver):
         The driver's type.
         """
         return Driver.POSTGRES
-
-    def _handle_sql_result_type_impl(self, t: type) -> type:
-        """
-        Some SQL query results are returned in different formats by certain
-        drivers. This function handles these cases by using custom type wrappers
-        which are capable of mapping sad results to their original type.
-
-        :param type t: The type that is to be mapped.
-        """
-        return t
 
     @staticmethod
     def std_colname(idx: int, colname: str) -> str:
@@ -202,8 +213,8 @@ class PostgresDriver(BaseDriver):
 
 class MySqlDriver(BaseDriver):
     """
-    This class represents the connection's underlying driver
-    and is used to handle driver-specific issues.
+    This class represents the underlying driver to a MySQL
+    database and is used to handle driver-specific issues.
     """
 
     @property
@@ -231,17 +242,16 @@ class MySqlDriver(BaseDriver):
             case _:
                 return super().handle_sql_param(param)
 
-    def _handle_sql_result_type_impl(self, t: type) -> type:
+    @override
+    def handle_sql_result_type(self, t: type) -> type:
         """
-        Some SQL query results are returned in different formats by certain
-        drivers. This function handles these cases by using custom type wrappers
-        which are capable of mapping sad results to their original type.
+        Maps `bool` types to `OnlymapsBool`.
 
         :param type t: The type that is to be mapped.
         """
         if t is bool:
             return OnlymapsBool
-        return t
+        return super().handle_sql_result_type(t)
 
     @staticmethod
     def std_colname(idx: int, colname: str) -> str:
@@ -260,8 +270,8 @@ class MySqlDriver(BaseDriver):
 
 class SqlServerDriver(BaseDriver):
     """
-    This class represents the connection's underlying driver
-    and is used to handle driver-specific issues.
+    This class represents the underlying driver to a Microsoft
+    SQL Server database and is used to handle driver-specific issues.
     """
 
     @property
@@ -271,17 +281,16 @@ class SqlServerDriver(BaseDriver):
         """
         return Driver.SQL_SERVER
 
-    def _handle_sql_result_type_impl(self, t: type) -> type:
+    @override
+    def handle_sql_result_type(self, t: type) -> type:
         """
-        Some SQL query results are returned in different formats by certain
-        drivers. This function handles these cases by using custom type wrappers
-        which are capable of mapping sad results to their original type.
+        Maps `bool` types to `OnlymapsBool`.
 
         :param type t: The type that is to be mapped.
         """
         if t is bool:
             return OnlymapsBool
-        return t
+        return super().handle_sql_result_type(t)
 
     @staticmethod
     def std_colname(idx: int, colname: str) -> str:
@@ -297,8 +306,8 @@ class SqlServerDriver(BaseDriver):
 
 class MariaDbDriver(BaseDriver):
     """
-    This class represents the connection's underlying driver
-    and is used to handle driver-specific issues.
+    This class represents the underlying driver to a MariaDB
+    database and is used to handle driver-specific issues.
     """
 
     @property
@@ -324,17 +333,16 @@ class MariaDbDriver(BaseDriver):
             case _:
                 return super().handle_sql_param(param)
 
-    def _handle_sql_result_type_impl(self, t: type) -> type:
+    @override
+    def handle_sql_result_type(self, t: type) -> type:
         """
-        Some SQL query results are returned in different formats by certain
-        drivers. This function handles these cases by using custom type wrappers
-        which are capable of mapping sad results to their original type.
+        Maps `bool` types to `OnlymapsBool`.
 
         :param type t: The type that is to be mapped.
         """
         if t is bool:
             return OnlymapsBool
-        return t
+        return super().handle_sql_result_type(t)
 
     @staticmethod
     def std_colname(idx: int, colname: str) -> str:
@@ -348,10 +356,73 @@ class MariaDbDriver(BaseDriver):
         return colname if colname != "?" else f"c{idx}"
 
 
+class OracleDbDriver(BaseDriver):
+    """
+    This class represents the underlying driver to an Oracle
+    database and is used to handle driver-specific issues.
+    """
+
+    @property
+    def tag(self) -> Driver:
+        """
+        The driver's type.
+        """
+        return Driver.ORACLE_DB
+
+    @override
+    def init_connection(self, conn: Any) -> None:
+        """
+        This function is used to perform any driver-specific
+        initialization logic right after the instantiation of
+        a PyDbAPIv2 connection.
+
+        :param Any conn: A PyDbAPIv2-compatible connection object.
+        """
+
+        def query_param_handler(
+            cursor: oracledb.Cursor, value: Any, num_elements: int
+        ) -> oracledb.Var | None:
+            """
+            Handles certain types of query parameters so that
+            no information is lost.
+            """
+            match value:
+                # Force `BINARY_DOUBLE` TYPE even if the decimal part is zero.
+                case float():
+                    return cursor.var(
+                        oracledb.DB_TYPE_BINARY_DOUBLE, arraysize=num_elements
+                    )
+                # Force `TIMESTAMP` type if datetime has microseconds.
+                case datetime() if value.microsecond > 0:
+                    return cursor.var(
+                        oracledb.DB_TYPE_TIMESTAMP, arraysize=num_elements
+                    )
+            return None
+
+        setattr(conn, "inputtypehandler", query_param_handler)
+
+    @staticmethod
+    def std_colname(idx: int, colname: str) -> str:
+        """
+        Assigns a unique column name to the provided column
+        name if it was not explicitly set by the user.
+
+        :param int idx: The column's index.
+        :param list[str] colnames: The column name to be fixed.
+        """
+        # NOTE: Due to OracleDB driver returning the expression itself
+        #       as the column name if one was not provided, there is
+        #       no way to know whether a name was provided or not.
+        # NOTE: Since all column names are converted to uppercase by default,
+        #       we should instead convert them back to lowercase as that is
+        #       the most common option for model fields.
+        return colname.lower()
+
+
 class SqlLiteDriver(BaseDriver):
     """
-    This class represents the connection's underlying driver
-    and is used to handle driver-specific issues.
+    This class represents the underlying driver to an SQLite
+    database and is used to handle driver-specific issues.
     """
 
     @property
@@ -361,17 +432,16 @@ class SqlLiteDriver(BaseDriver):
         """
         return Driver.SQL_LITE
 
-    def _handle_sql_result_type_impl(self, t: type) -> type:
+    @override
+    def handle_sql_result_type(self, t: type) -> type:
         """
-        Some SQL query results are returned in different formats by certain
-        drivers. This function handles these cases by using custom type wrappers
-        which are capable of mapping sad results to their original type.
+        Maps `bool` types to `OnlymapsBool`.
 
         :param type t: The type that is to be mapped.
         """
         if t is bool:
             return OnlymapsBool
-        return t
+        return super().handle_sql_result_type(t)
 
     @staticmethod
     def std_colname(idx: int, colname: str) -> str:
@@ -404,16 +474,6 @@ class UnknownDriver(BaseDriver):
         Returns an `UnknownDriver` instance.
         """
         return cls(apilevel="2.0", threadsafety=0, paramstyle=ParamStyle.UNKNOWN)
-
-    def _handle_sql_result_type_impl(self, t: type) -> type:
-        """
-        Some SQL query results are returned in different formats by certain
-        drivers. This function handles these cases by using custom type wrappers
-        which are capable of mapping sad results to their original type.
-
-        :param type t: The type that is to be mapped.
-        """
-        return t
 
     @staticmethod
     def std_colname(idx: int, colname: str) -> str:
@@ -451,6 +511,8 @@ def driver_factory(
             factory = SqlServerDriver
         case Driver.MARIA_DB:
             factory = MariaDbDriver
+        case Driver.ORACLE_DB:
+            factory = OracleDbDriver
         case Driver.SQL_LITE:
             factory = SqlLiteDriver
         case Driver.UNKNOWN:  # pragma: no cover

--- a/onlymaps/_drivers.py
+++ b/onlymaps/_drivers.py
@@ -11,6 +11,7 @@ import json
 from abc import ABC, abstractmethod
 from dataclasses import is_dataclass
 from datetime import datetime
+from decimal import Decimal
 from enum import Enum, StrEnum
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Callable, Self, TypeVar, final
@@ -431,6 +432,22 @@ class SqlLiteDriver(BaseDriver):
         The driver's type.
         """
         return Driver.SQL_LITE
+
+    @override
+    def handle_sql_param(self, param: Any) -> Any:
+        """
+        Some Python types are not supported by certain drivers. This function
+        handles these cases and maps parameters of these types to a type that
+        is supported.
+
+        :param Any param: An SQL query parameter.
+        """
+        match param:
+            # Sqlite3 driver cannot handle `Decimal` objects.
+            case Decimal():
+                return str(param)
+            case _:
+                return super().handle_sql_param(param)
 
     @override
     def handle_sql_result_type(self, t: type) -> type:

--- a/onlymaps/_drivers.py
+++ b/onlymaps/_drivers.py
@@ -410,7 +410,7 @@ class OracleDbDriver(BaseDriver):
         :param int idx: The column's index.
         :param list[str] colnames: The column name to be fixed.
         """
-        # NOTE: Due to OracleDB driver returning the expression itself
+        # NOTE: Due to the OracleDB driver returning the expression itself
         #       as the column name if one was not provided, there is
         #       no way to know whether a name was provided or not.
         # NOTE: Since all column names are converted to uppercase by default,

--- a/onlymaps/_pool.py
+++ b/onlymaps/_pool.py
@@ -295,7 +295,7 @@ class ConnectionPool:
     @require_open
     def fetch_one_or_none(  # <async>
         self, t: type[T] | EllipsisType, sql: str, /, *args: Any, **kwargs: Any
-    ) -> T | None:
+    ) -> T | Any | None:
         """
         Executes the query and returns a single row object of type `T`,
         if the query resulted in such object, else returns `None`.
@@ -316,7 +316,7 @@ class ConnectionPool:
     @require_open
     def fetch_one(  # <async>
         self, t: type[T] | EllipsisType, sql: str, /, *args: Any, **kwargs: Any
-    ) -> T:
+    ) -> T | Any:
         """
         Executes the query and returns a single row object of type `T`.
 
@@ -337,7 +337,7 @@ class ConnectionPool:
     @require_open
     def fetch_many(  # <async>
         self, t: type[T] | EllipsisType, sql: str, /, *args: Any, **kwargs: Any
-    ) -> list[T]:
+    ) -> list[T] | list[Any]:
         """
         Executes the query and returns a a list of row objects of type `T`.
 
@@ -363,7 +363,7 @@ class ConnectionPool:
         /,
         *args: Any,
         **kwargs: Any,
-    ) -> Iterator[Iterator[list[T]]]:  # <async>  # <async>
+    ) -> Iterator[Iterator[list[T]] | Iterator[list[Any]]]:  # <async>
         """
         Executes the query and returns an iterator on batches of row objects
         of type `T`. Each batch of rows is loaded into memory during the

--- a/onlymaps/_pool.py
+++ b/onlymaps/_pool.py
@@ -282,10 +282,10 @@ class ConnectionPool:
         Executes the given SQL query.
 
         :param str sql: The SQL query to be executed.
-        :param tuple[Any, ...] params: A tuple containing positional
-            parameters for the query.
-        :param dict[str, Any] kwparams: A dictionary containing keyword
-            parameters for the query.
+        :param Any *args: A sequence of positional arguments to be used
+            as query parameters.
+        :param Any **kwargs: A sequence of keyword arguments to be used
+            as query parameters.
 
         :raises RuntimeError: Connection is not open.
         """
@@ -303,10 +303,10 @@ class ConnectionPool:
         :param `T` | ellipsis t: The type to which the query result is mapped.
             If an `ellipsis` is provided, then no type check/cast occurs.
         :param str sql: The SQL query to be executed.
-        :param tuple[Any, ...] params: A tuple containing positional
-            parameters for the query.
-        :param dict[str, Any] kwparams: A dictionary containing keyword
-            parameters for the query.
+        :param Any *args: A sequence of positional arguments to be used
+            as query parameters.
+        :param Any **kwargs: A sequence of keyword arguments to be used
+            as query parameters.
 
         :raises RuntimeError: Connection is not open.
         """
@@ -323,10 +323,10 @@ class ConnectionPool:
         :param `T` | ellipsis t: The type to which the query result is mapped.
             If an `ellipsis` is provided, then no type check/cast occurs.
         :param str sql: The SQL query to be executed.
-        :param tuple[Any, ...] params: A tuple containing positional
-            parameters for the query.
-        :param dict[str, Any] kwparams: A dictionary containing keyword
-            parameters for the query.
+        :param Any *args: A sequence of positional arguments to be used
+            as query parameters.
+        :param Any **kwargs: A sequence of keyword arguments to be used
+            as query parameters.
 
         :raises ValueError: No row object was found to return.
         :raises RuntimeError: Connection is not open.
@@ -344,10 +344,10 @@ class ConnectionPool:
         :param `T` | ellipsis t: The type to which the query result is mapped.
             If an `ellipsis` is provided, then no type check/cast occurs.
         :param str sql: The SQL query to be executed.
-        :param tuple[Any, ...] params: A tuple containing positional
-            parameters for the query.
-        :param dict[str, Any] kwparams: A dictionary containing keyword
-            parameters for the query.
+        :param Any *args: A sequence of positional arguments to be used
+            as query parameters.
+        :param Any **kwargs: A sequence of keyword arguments to be used
+            as query parameters.
 
         :raises RuntimeError: Connection is not open.
         """
@@ -377,10 +377,10 @@ class ConnectionPool:
             If an `ellipsis` is provided, then no type check/cast occurs.
         :param int size: The number of rows each batch contains.
         :param str sql: The SQL query to be executed.
-        :param tuple[Any, ...] params: A tuple containing positional
-            parameters for the query.
-        :param dict[str, Any] kwparams: A dictionary containing keyword
-            parameters for the query.
+        :param Any *args: A sequence of positional arguments to be used
+            as query parameters.
+        :param Any **kwargs: A sequence of keyword arguments to be used
+            as query parameters.
 
         :raises RuntimeError: Connection is not open.
         """

--- a/onlymaps/_query.py
+++ b/onlymaps/_query.py
@@ -254,14 +254,14 @@ class Query:
 
             if cursor.description and _type is not NoneType:
 
-                adapter, map_to_original = self.__driver.handle_sql_result_type(
+                adapter, inverse_map = self.__driver.get_adapter_and_inverse_map(
                     cast(Hashable, _type)
                 )
 
                 def deser(obj: Any) -> T:
                     try:
                         parsed = adapter.validate_python(obj, strict=STRICT_MODE)
-                        return cast(T, map_to_original(parsed))
+                        return cast(T, inverse_map(parsed))
                     except ValidationError as exc:
                         err = exc.errors()[0]
                         err_msg = err["msg"]

--- a/onlymaps/_query.py
+++ b/onlymaps/_query.py
@@ -181,10 +181,14 @@ class Query:
             nonlocal is_bulk
             match param:
                 case Bulk():
+
                     if not allow_bulk:
                         raise ValueError("Use method `exec` for bulk statements.")
+
                     is_bulk = True
-                    return param.value
+
+                    return param.get_mapped_value(self.__driver.handle_sql_param)
+
                 case _ if is_bulk:
                     raise ValueError(
                         "Cannot provide additional parameters in `_bulk` mode."

--- a/onlymaps/_spec.py
+++ b/onlymaps/_spec.py
@@ -38,7 +38,7 @@ class PyDbAPIv2Cursor(Protocol):
     def execute(  # <async>
         self,
         operation: str,
-        params: dict[str, Any] | Sequence[Any] = ...,
+        params: dict[str, Any] | list[Any] | tuple[Any, ...] = ...,
         /,
         *args: Any,
         **kwargs: Any,
@@ -64,7 +64,9 @@ class PyDbAPIv2Cursor(Protocol):
         See: https://peps.python.org/pep-0249/#fetchmany
         """
 
-    def close(self) -> bool | None:  # <async>
+    def close(
+        self,
+    ) -> bool | None:  # <replace:) -> bool | None | Awaitable[None]:>
         """
         See: https://peps.python.org/pep-0249/#Cursor.close
         """

--- a/onlymaps/_spec.py
+++ b/onlymaps/_spec.py
@@ -84,12 +84,12 @@ class PyDbAPIv2Connection(Protocol):
         See: https://peps.python.org/pep-0249/#Connection.close
         """
 
-    def commit(self) -> None:  # <async>
+    def commit(self) -> Any | None:  # <async>
         """
         See: https://peps.python.org/pep-0249/#commit
         """
 
-    def rollback(self) -> None:  # <async>
+    def rollback(self) -> Any | None:  # <async>
         """
         See: https://peps.python.org/pep-0249/#rollback
         """

--- a/onlymaps/_types.py
+++ b/onlymaps/_types.py
@@ -111,7 +111,7 @@ class OnlymapsType(ABC, Generic[T]):
         back to their original type.
 
         :param type t: The type to be mapped.
-        :param ((type) -> (type | type)) | None field_type_mapper: A
+        :param `(type) -> type` | None field_type_mapper: A
             field type mapping function used for custom type handling.
         """
 
@@ -123,29 +123,31 @@ class OnlymapsType(ABC, Generic[T]):
 
         adapter = TypeAdapter(t)
 
-        def map_to_original(obj: Any) -> T:
+        def inverse_map(obj: Any) -> T:
             jsonable = to_jsonable_python(obj)
             return adapter.validate_python(jsonable, strict=False)
 
         if t in CLASS_MAP:
-            return CLASS_MAP[t], map_to_original
+            return CLASS_MAP[t], inverse_map
 
         origin: type = get_origin(t) or t
 
         if isclass(origin) and issubclass(origin, Enum):
-            return OnlymapsEnum.from_enum(origin), map_to_original
+            return OnlymapsEnum.from_enum(origin), inverse_map
 
-        if args := get_args(t):
-            t = cls._parametrize(origin, args, field_type_mapper)
+        args = get_args(t)
 
         if origin is tuple:
-            return OnlymapsTuple.from_args(args, field_type_mapper), map_to_original
+            return OnlymapsTuple.from_args(args, field_type_mapper), inverse_map
         if origin is list:
-            return OnlymapsList.from_args(args, field_type_mapper), map_to_original
+            return OnlymapsList.from_args(args, field_type_mapper), inverse_map
         if origin is set:
-            return OnlymapsSet.from_args(args, field_type_mapper), map_to_original
+            return OnlymapsSet.from_args(args, field_type_mapper), inverse_map
         if origin is dict:
-            return OnlymapsDict.from_args(args, field_type_mapper), map_to_original
+            return OnlymapsDict.from_args(args, field_type_mapper), inverse_map
+
+        if args:
+            t = cls._parametrize(origin, args, field_type_mapper)
 
         return t, lambda x: x
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ pymssql = [
 oracledb = [
   "oracledb == 3.4.1"
 ]
+duckdb = [
+  "duckdb == 1.4.3"
+]
 aiomysql = [
   "aiomysql == 0.3.2"
 ]
@@ -56,6 +59,7 @@ all = [
   "mariadb == 1.1.14",
   "pymssql == 2.3.8",
   "oracledb == 3.4.1",
+  "duckdb == 1.4.3",
   "aiomysql == 0.3.2",
   "aiosqlite == 0.21.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ mariadb = [
 pymssql = [
   "pymssql == 2.3.8"
 ]
+oracledb = [
+  "oracledb == 3.4.1"
+]
 aiomysql = [
   "aiomysql == 0.3.2"
 ]
@@ -59,7 +62,7 @@ all = [
 dev = [
   "pytest==9.0.1",
   "pytest-asyncio==1.3.0",
-  "testcontainers[postgres,mysql,mssql]==4.13.2",
+  "testcontainers[postgres,mysql,mssql,oracle-free]==4.13.2",
   "coverage==7.2.1",
   "mypy==1.18.2",
   "pylint==3.3.1",
@@ -85,6 +88,7 @@ disallow_untyped_defs = true
 
 [[tool.mypy.overrides]]
 module = [
+  "onlymaps.asyncio.*",
   "onlymaps._version.py",
   "mariadb.*",
   "aiomysql.*",
@@ -106,7 +110,7 @@ max-args = 10
 max-positional-arguments = 10
 max-attributes = 12
 max-returns = 10
-max-branches = 15
+max-branches = 20
 
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ all = [
   "types-PyMySQL == 1.1.0.20250916",
   "mariadb == 1.1.14",
   "pymssql == 2.3.8",
+  "oracledb == 3.4.1",
   "aiomysql == 0.3.2",
   "aiosqlite == 0.21.0"
 ]

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -14,4 +14,5 @@ disable=
     R0904, # (too-many-public-methods)
     R0913, # (too-many-arguments)
     R0914, # (too-many-locals)
+    R0915, # (too-many-statements)
     R0917, # (too-many-positional-arguments)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ This module imports all fixtures that are to be available globally.
 from tests.fixtures.connections import connection, connection_B, pool
 from tests.fixtures.containers import (
     db_container,
+    duckdb_container,
     mariadb_container,
     mysql_container,
     oracledb_container,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from tests.fixtures.containers import (
     db_container,
     mariadb_container,
     mysql_container,
+    oracledb_container,
     pg_container,
     sql_server_container,
     sqlite_container,

--- a/tests/fixtures/connections.py
+++ b/tests/fixtures/connections.py
@@ -23,7 +23,7 @@ from tests.utils import (
     POOL_WAIT_TIMEOUT,
     DbContainer,
     SqliteContainer,
-    conn_str_from_container,
+    get_conn_str_and_kwargs_from_container,
     get_request_param,
 )
 
@@ -38,18 +38,9 @@ def connection(  # <async>
 
     param = get_request_param(request)
 
-    conn = Connection.from_conn_str(
-        conn_str_from_container(db_container),
-        connect_timeout=CONNECT_TIMEOUT,
-        **(
-            # NOTE: Set this to `False` so as to be able to use
-            # this connection instance in a separate thread
-            # when connected to an sqlite database.
-            {"check_same_thread": False}
-            if isinstance(db_container, SqliteContainer)
-            else {}
-        ),
-    )
+    conn_str, kwargs = get_conn_str_and_kwargs_from_container(db_container)
+
+    conn = Connection.from_conn_str(conn_str, **kwargs)
 
     if param == Driver.UNKNOWN:
         conn_factory = getattr(conn, "_Connection__conn_factory")
@@ -73,7 +64,9 @@ def pool(  # <async>
 
     driver = get_request_param(request)
 
-    kwargs: dict[str, Any] = {
+    conn_str, kwargs = get_conn_str_and_kwargs_from_container(db_container)
+
+    pool_kwargs: dict[str, Any] = {
         "min_pool_size": MIN_POOL_SIZE,
         "max_pool_size": MAX_POOL_SIZE,
         "wait_timeout": POOL_WAIT_TIMEOUT,
@@ -85,15 +78,13 @@ def pool(  # <async>
     if driver == Driver.SQL_LITE:
         kwargs["timeout"] = 10000
 
-    conn = ConnectionPool.from_conn_str(
-        conn_str_from_container(db_container), connect_timeout=CONNECT_TIMEOUT, **kwargs
-    )
+    conn = ConnectionPool.from_conn_str(conn_str, **pool_kwargs, **kwargs)
 
     if driver == Driver.UNKNOWN:
         conn_factory: PyDbAPIv2ConnectionFactory = getattr(
             conn, "_ConnectionPool__conn_factory"
         )
-        conn = ConnectionPool(conn_factory, **kwargs)
+        conn = ConnectionPool(conn_factory, **pool_kwargs)
 
     conn.open()  # <await>
 

--- a/tests/fixtures/connections.py
+++ b/tests/fixtures/connections.py
@@ -72,12 +72,6 @@ def pool(  # <async>
         "wait_timeout": POOL_WAIT_TIMEOUT,
     }
 
-    # NOTE: In the case of Sqlite use an extremely large
-    #       timeout so as not to get a locked database error.
-    #       See: https://docs.python.org/3/library/sqlite3.html#sqlite3.connect
-    if driver == Driver.SQL_LITE:
-        kwargs["timeout"] = 10000
-
     conn = ConnectionPool.from_conn_str(conn_str, **pool_kwargs, **kwargs)
 
     if driver == Driver.UNKNOWN:

--- a/tests/fixtures/containers.py
+++ b/tests/fixtures/containers.py
@@ -8,6 +8,7 @@ a database via a Docker container.
 
 import gc
 import os
+import re
 import sqlite3
 from time import sleep
 from typing import Iterator
@@ -17,6 +18,7 @@ import pytest
 from pytest import FixtureRequest
 from testcontainers.mssql import SqlServerContainer
 from testcontainers.mysql import MySqlContainer
+from testcontainers.oracle import OracleDbContainer
 from testcontainers.postgres import PostgresContainer
 
 from onlymaps._drivers import Driver
@@ -109,6 +111,62 @@ def sql_server_container() -> Iterator[SqlServerContainer]:
 
 
 @pytest.fixture(scope="session")
+def oracledb_container() -> Iterator[OracleDbContainer]:
+    """
+    A fixture used to set up an OracleDB Docker container.
+    """
+
+    with OracleDbContainer(image="gvenzl/oracle-free:slim") as oracledb:
+
+        conn_str = oracledb.get_connection_url()
+
+        m = re.fullmatch(
+            r"oracle\+oracledb://(.+):(.+)@.+/\?service_name=(.+)", conn_str
+        )
+        assert m is not None
+
+        username, password, dbname = m.groups()
+
+        # NOTE: Increase the number of processes and restart the database.
+        #       Do this due to an error that sometimes occurs during opening
+        #       a new connection:
+        #
+        #       oracledb.exceptions.OperationalError:
+        #           DPY-6005: cannot connect to database (CONNECTION_ID=3uxZaUf0IUknsi7pokzdtg==).
+        #           DPY-6000: Listener refused connection. (Similar to ORA-12516)
+        oracledb.exec(
+            [
+                "bash",
+                "-c",
+                (
+                    "echo 'ALTER SYSTEM SET processes=500 SCOPE=spfile;' | sqlplus / as sysdba"
+                    " && echo 'SHUTDOWN IMMEDIATE' | sqlplus / as sysdba"
+                    " && echo 'STARTUP' | sqlplus / as sysdba"
+                ),
+            ]
+        )
+
+        # Create any necessary tables.
+        oracledb.exec(
+            [
+                "bash",
+                "-c",
+                (
+                    f"echo '{SQL.CREATE_TEST_TABLE};' | "
+                    "sqlplus -s "
+                    f"{username}/{password}@{dbname}"
+                ),
+            ]
+        )
+
+        oracledb.username = username
+        oracledb.password = password
+        oracledb.dbname = dbname
+
+        yield oracledb
+
+
+@pytest.fixture(scope="session")
 def sqlite_container() -> Iterator[SqliteContainer]:
     """
     A fixture used to set up a pseudo SQLite container.
@@ -148,6 +206,8 @@ def db_container(request: FixtureRequest) -> DbContainer:
             container = "sql_server_container"
         case Driver.MARIA_DB:
             container = "mariadb_container"
+        case Driver.ORACLE_DB:
+            container = "oracledb_container"
         case Driver.SQL_LITE:
             container = "sqlite_container"
         case _:  # pragma: no cover

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -17,8 +17,8 @@ from tests.fixtures.connections import db, dbapiv2
 from tests.fixtures.containers import db_container
 from tests.utils import DRIVERS, DbContainer, get_conn_str_and_kwargs_from_container
 
-# NOTE: Do not incude SQL Server for async tests.
-# <include:DRIVERS = [d for d in DRIVERS if d != Driver.SQL_SERVER]>
+# NOTE: Do not incude SQL Server / DuckDB for async tests.
+# <include:DRIVERS = [d for d in DRIVERS if d not in {Driver.SQL_SERVER, Driver.DUCK_DB}]>
 
 
 @pytest.mark.parametrize("db_container", DRIVERS, indirect=True)

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -17,7 +17,7 @@ from tests.fixtures.connections import db, dbapiv2
 from tests.fixtures.containers import db_container
 from tests.utils import DRIVERS, DbContainer, get_conn_str_and_kwargs_from_container
 
-# NOTE: Do not incude SQL Server / DuckDB for async tests.
+# NOTE: Exclude certain drivers from async tests.
 # <include:DRIVERS = [d for d in DRIVERS if d not in {Driver.SQL_SERVER, Driver.DUCK_DB}]>
 
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -19,7 +19,7 @@ from tests.utils import DRIVERS, SQL
 
 # <include:from tests.utils import Driver>
 
-# NOTE: Do not incude SQL Server / DuckDB for async tests.
+# NOTE: Exclude certain drivers from async tests.
 # <include:DRIVERS = [d for d in DRIVERS if d not in {Driver.SQL_SERVER, Driver.DUCK_DB}]>
 
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -113,15 +113,18 @@ class TestConnection:  # <replace:class TestAsyncConnection:>
         ctx = getattr(connection, ctx_method)
         blocked = getattr(connection, blocked_method)
 
-        result: int
+        result: int = 0
         continue_flag: bool = False
 
         def open_transaction_or_iter() -> None:  # <async>
             nonlocal continue_flag, result
-            with ctx(*ctx_args) as _:  # <async>
+            try:
+                with ctx(*ctx_args) as _:  # <async>
+                    continue_flag = True
+                    sleep(1)  # <await>
+                    result += 1
+            finally:
                 continue_flag = True
-                sleep(1)  # <await>
-                result = 1
 
         def run_query() -> None:  # <async>
             nonlocal continue_flag, result
@@ -135,7 +138,7 @@ class TestConnection:  # <replace:class TestAsyncConnection:>
             else:
                 blocked(*blocked_args)  # <await>
 
-            result = 2
+            result += 1
 
         executor.submit(open_transaction_or_iter)
         executor.submit(run_query)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -17,9 +17,10 @@ from tests.fixtures.connections import connection, connection_B, dbapiv2
 from tests.fixtures.executors import Executor
 from tests.utils import DRIVERS, SQL
 
-# NOTE: Do not incude SQL Server for async tests.
 # <include:from tests.utils import Driver>
-# <include:DRIVERS = [d for d in DRIVERS if d != Driver.SQL_SERVER]>
+
+# NOTE: Do not incude SQL Server / DuckDB for async tests.
+# <include:DRIVERS = [d for d in DRIVERS if d not in {Driver.SQL_SERVER, Driver.DUCK_DB}]>
 
 
 @pytest.mark.parametrize("connection", DRIVERS, indirect=True)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -7,6 +7,7 @@ This module contains tests related to the `Database` interface.
 
 from functools import partial
 from threading import Lock  # <replace:from asyncio import Lock>
+from time import sleep  # <replace:from asyncio import sleep>
 from typing import Any, Callable, ContextManager, Iterator
 
 import pytest
@@ -291,6 +292,10 @@ class TestDatabase:  # <replace:class TestAsyncDatabase:>
             # locking, not MVCC, therefore the query should fail
             # instead due to the lock held on the table.
             if db.driver == Driver.SQL_SERVER:
+                # NOTE: Sleep for a little bit to ensure the database
+                #       has locked the table, as sometimes not waiting
+                #       might cause this test to fail.
+                sleep(0.5)  # <await>
                 with pytest.raises(Exception):
                     connection_B.fetch_one_or_none(  # <await>
                         int, SQL.SELECT_FROM_TEST_TABLE(db.driver), uid

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -30,8 +30,8 @@ from tests.utils import (
     handle_scalar_param,
 )
 
-# NOTE: Do not incude SQL Server for async tests.
-# <include:DRIVERS = [d for d in DRIVERS if d != Driver.SQL_SERVER]>
+# NOTE: Do not incude SQL Server / DuckDB for async tests.
+# <include:DRIVERS = [d for d in DRIVERS if d not in {Driver.SQL_SERVER, Driver.DUCK_DB}]>
 
 
 @pytest.mark.parametrize("pooling", [False, True])

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -30,7 +30,7 @@ from tests.utils import (
     handle_scalar_param,
 )
 
-# NOTE: Do not incude SQL Server / DuckDB for async tests.
+# NOTE: Exclude certain drivers from async tests.
 # <include:DRIVERS = [d for d in DRIVERS if d not in {Driver.SQL_SERVER, Driver.DUCK_DB}]>
 
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -194,12 +194,14 @@ class TestConnectionPool:  # <replace:class TestAsyncConnectionPool:>
 
 @pytest.mark.parametrize(
     "small_pool",
-    # NOTE: Do not test on `sql_sever` and `sql_lite` as there is not
-    #       an easy way to implicitly force the DB to close the connection
+    # NOTE: Do not test on certain drivers as there is not
+    #       an easy way to either explicitly or implicitly
+    #       force the DB to close the connection from within
+    #       the same connection.
     [
         driver
         for driver in DRIVERS
-        if driver not in {Driver.SQL_SERVER, Driver.SQL_LITE}
+        if driver not in {Driver.SQL_SERVER, Driver.ORACLE_DB, Driver.SQL_LITE}
     ],
     indirect=True,
 )

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -20,8 +20,8 @@ from tests.fixtures.connections import big_pool, connection, pool, small_pool
 from tests.fixtures.executors import Executor
 from tests.utils import DRIVERS, MAX_POOL_SIZE, SQL
 
-# NOTE: Do not incude SQL Server for async tests.
-# <include:DRIVERS = [d for d in DRIVERS if d != Driver.SQL_SERVER]>
+# NOTE: Do not incude SQL Server / DuckDB for async tests.
+# <include:DRIVERS = [d for d in DRIVERS if d not in {Driver.SQL_SERVER, Driver.DUCK_DB}]>
 
 
 @pytest.mark.parametrize("pool", DRIVERS, indirect=True)
@@ -201,7 +201,8 @@ class TestConnectionPool:  # <replace:class TestAsyncConnectionPool:>
     [
         driver
         for driver in DRIVERS
-        if driver not in {Driver.SQL_SERVER, Driver.ORACLE_DB, Driver.SQL_LITE}
+        if driver
+        not in {Driver.SQL_SERVER, Driver.ORACLE_DB, Driver.SQL_LITE, Driver.DUCK_DB}
     ],
     indirect=True,
 )

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -20,7 +20,7 @@ from tests.fixtures.connections import big_pool, connection, pool, small_pool
 from tests.fixtures.executors import Executor
 from tests.utils import DRIVERS, MAX_POOL_SIZE, SQL
 
-# NOTE: Do not incude SQL Server / DuckDB for async tests.
+# NOTE: Exclude certain drivers from async tests.
 # <include:DRIVERS = [d for d in DRIVERS if d not in {Driver.SQL_SERVER, Driver.DUCK_DB}]>
 
 
@@ -132,7 +132,7 @@ class TestConnectionPool:  # <replace:class TestAsyncConnectionPool:>
 
         assert exc_info.value == Error.PoolIteratorNotAllowed
 
-    def test_connection_pool_on_multuple_iter_allowed(  # <async>
+    def test_connection_pool_on_multiple_iter_allowed(  # <async>
         self, pool: ConnectionPool, executor: Executor
     ) -> None:
         """

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -34,8 +34,8 @@ from tests.utils import (
     handle_scalar_param,
 )
 
-# NOTE: Do not incude SQL Server for async tests.
-# <include:DRIVERS = [d for d in DRIVERS if d != Driver.SQL_SERVER]>
+# NOTE: Do not incude SQL Server / DuckDB for async tests.
+# <include:DRIVERS = [d for d in DRIVERS if d not in {Driver.SQL_SERVER, Driver.DUCK_DB}]>
 
 
 @pytest.mark.parametrize("pooling", [False, True])

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -34,7 +34,7 @@ from tests.utils import (
     handle_scalar_param,
 )
 
-# NOTE: Do not incude SQL Server / DuckDB for async tests.
+# NOTE: Exclude certain drivers from async tests.
 # <include:DRIVERS = [d for d in DRIVERS if d not in {Driver.SQL_SERVER, Driver.DUCK_DB}]>
 
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -333,6 +333,94 @@ class TestQuery:  # <replace:class TestAsyncQuery:>
             query = SQL.SELECT_SINGLE_SCALAR(db.driver)
             db.fetch_one(int, query, "a")  # <await>
 
+    def test_query_on_complex_bulk_with_sequence_args(  # <async>
+        self, db: Database
+    ) -> None:
+        """
+        Tests whether arguments are properly handled when wrapped
+        within a `Bulk` argument containing sequence arguments.
+        """
+
+        if db.driver in {Driver.SQL_SERVER, Driver.ORACLE_DB}:
+            pytest.skip(
+                reason="Temporary tables not supported or need different syntax."
+            )
+
+        tmp_table = "tmp_table"
+        c1, c2 = "c1", "c2"
+
+        db.exec(  # <await>
+            f"""
+            CREATE TEMPORARY TABLE {tmp_table} (
+                {c1} VARCHAR(100),
+                {c2} VARCHAR(100)
+            )
+            """
+        )
+
+        class PydanticModel(BaseModel):
+            """
+            A simple pydantic model class.
+            """
+
+            n: int
+
+        params = [[Json([i]), PydanticModel(n=i)] for i in range(5)]
+
+        plchld_1 = SQL.placeholder(db.driver, n=1)
+        plchld_2 = SQL.placeholder(db.driver, n=2)
+
+        # Asserts no exception is raised.
+        db.exec(  # <await>
+            f"INSERT INTO {tmp_table}({c1}, {c2}) VALUES({plchld_1}, {plchld_2})",
+            Bulk(params),
+        )
+
+    def test_query_on_complex_bulk_with_mapping_args(  # <async>
+        self, db: Database
+    ) -> None:
+        """
+        Tests whether arguments are properly handled when wrapped
+        within a `Bulk` argument containing mapping arguments.
+        """
+
+        if db.driver in {Driver.SQL_SERVER, Driver.ORACLE_DB}:
+            pytest.skip(
+                reason="Temporary tables not supported or need different syntax."
+            )
+
+        tmp_table = "tmp_table"
+        c1, c2 = "c1", "c2"
+
+        db.exec(  # <await>
+            f"""
+            CREATE TEMPORARY TABLE {tmp_table} (
+                {c1} VARCHAR(100),
+                {c2} VARCHAR(100)
+            )
+            """
+        )
+
+        class PydanticModel(BaseModel):
+            """
+            A simple pydantic model class.
+            """
+
+            n: int
+
+        params = [
+            {"scalar1": Json([i]), "scalar2": PydanticModel(n=i)} for i in range(5)
+        ]
+
+        plchld_1 = SQL.kw_placeholder(db.driver, n=1)
+        plchld_2 = SQL.kw_placeholder(db.driver, n=2)
+
+        # Asserts no exception is raised.
+        db.exec(  # <await>
+            f"INSERT INTO {tmp_table}({c1}, {c2}) VALUES({plchld_1}, {plchld_2})",
+            Bulk(params),
+        )
+
     @pytest.mark.parametrize("method", ["fetch_one", "fetch_one_or_none", "fetch_many"])
     def test_query_on_bulk_param(self, db: Database, method: str) -> None:  # <async>
         """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,6 +8,7 @@ that are to be used for testing purposes.
 
 from dataclasses import is_dataclass, make_dataclass
 from datetime import date, datetime
+from decimal import Decimal
 from enum import IntEnum, StrEnum
 from typing import Any, TypeAlias, Union
 from uuid import UUID
@@ -62,6 +63,7 @@ SCALAR_TYPE = Union[
     bool,
     int,
     float,
+    Decimal,
     str,
     bytes,
     UUID,
@@ -172,6 +174,7 @@ def _build_values() -> tuple[list[SCALAR_TYPE], list[ROW_TYPE], type[BaseModel]]
         True,
         1,
         1.0,
+        Decimal("1.0"),
         "Hello",
         b"Hello",
         UUID("3d751e08-dd90-4045-b1ee-7cfd392618a6"),


### PR DESCRIPTION
### Added

- Oracle databases are now supported via driver `oracledb`. [#5]
- DuckDB databases are now supported via driver `duckdb`. [#14]
- Added support for `decimal.Decimal` type. [#13]
- (INTERNAL) `BaseDriver` subclasses can now optionally implement an `init_connection` method which is called right after a `PyDbAPIv2Connection` is created so as to perform any driver-specific initialization steps on said connection. [#5], [#14]
- (INTERNAL) `BaseDriver` subclasses can now optionally implement an `init_transaction` method which is called right before a
transaction is to be started so as to perform any driver-specific initialization steps regarding the transaction. [#14]


### Changed

- (INTERNAL) Renamed certain functions to better convey their meaning. [#5]
- (INTERNAL) Simplified method `onlymaps._connection.Connection._safe_cursor` by moving the cursor-obtaining logic into a
separate method `__cursor`. [#10]
- (INTERNAL) Added private method `onlymaps._connection.Connection.__close` so as to remove duplicated logic. [#10]
- (INTERNAL) Minor code improvements and fixes in `onlymaps._utils.py` and `tests.utils.py`. [#11]

### Fixed

- Bug that resulted in query parameters not being properly handled when wrapped within
  `Bulk`. [#8]